### PR TITLE
Use Ed base key for fileserver, with X keys for onion requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /fileserver/config.py
 __pycache__
+/key_ed25519
 /key_x25519
 .vscode
 .venv

--- a/fileserver/crypto.py
+++ b/fileserver/crypto.py
@@ -1,7 +1,38 @@
-import nacl.public
+from nacl.public import PrivateKey
+from nacl.signing import SigningKey
 import os
 
 from .web import app
+
+# We support up to *2* possible private keys: one derived from an Ed secret key, the other directly
+# from an X private key value.  This is for transition towards deriving everything from an Ed secret
+# key, but with existing clients using a known X privkey.
+privkeys = []
+
+sk = None
+
+if os.path.exists("key_ed25519"):
+    with open("key_ed25519", "rb") as f:
+        key = f.read()
+        if len(key) == 128 and all(c in '0123456789abcdefABCDEF' for c in key):
+            key = bytes.fromhex(key)
+        elif (len(key) == 129 and key[-1:] == b"\n") or (len(key) == 130 and key[-2:] == b"\r\n"):
+            key = bytes.fromhex(key[0:128].decode())
+        elif len(key) != 64:
+            raise RuntimeError(f"Invalid key_ed25519: expected 64 bytes or 128 hex, not {len(key)} bytes\n{repr(key)}")
+
+    sk = SigningKey(key[0:32])
+    privkeys.append(sk.to_curve25519_private_key())
+else:
+    sk = SigningKey.generate()
+    privkeys.append(sk.to_curve25519_private_key())
+    with open("key_ed25519", "wb") as f:
+        f.write((sk.encode().hex() + sk.verify_key.encode().hex() + "\n").encode())
+
+app.logger.info(
+        f"File server Ed25519 pubkey: {sk.verify_key.encode().hex()}")
+app.logger.info(
+        f"... which is X25519 pubkey: {sk.to_curve25519_private_key().public_key.encode().hex()}")
 
 if os.path.exists("key_x25519"):
     with open("key_x25519", "rb") as f:
@@ -10,18 +41,9 @@ if os.path.exists("key_x25519"):
             raise RuntimeError(
                 "Invalid key_x25519: expected 32 bytes, not {} bytes".format(len(key))
             )
-    privkey = nacl.public.PrivateKey(key)
-else:
-    privkey = nacl.public.PrivateKey.generate()
-    with open("key_x25519", "wb") as f:
-        f.write(privkey.encode())
+    privkeys.append(PrivateKey(key))
 
-_privkey_bytes = privkey.encode()
-server_pubkey = privkey.public_key
-server_pubkey_bytes = server_pubkey.encode()
+    app.logger.info(f"File server X25519-only pubkey: {privkeys[-1].public_key.encode().hex()}")
 
-app.logger.info(
-    "File server pubkey: {}".format(
-        privkey.public_key.encode(encoder=nacl.encoding.HexEncoder).decode()
-    )
-)
+_server_privkey_bytes = [x.encode() for x in privkeys]
+_server_pubkey_bytes = [x.public_key.encode() for x in privkeys]

--- a/fileserver/onion_req.py
+++ b/fileserver/onion_req.py
@@ -104,13 +104,16 @@ def handle_v4_onionreq_plaintext(body):
 
 
 def decrypt_onionreq():
-    try:
-        return OnionReqParser(
-            crypto.server_pubkey_bytes,
-            crypto._privkey_bytes,
-            request.data)
-    except Exception as e:
-        app.logger.warning("Failed to decrypt onion request: {}".format(e))
+    for i in range(len(crypto._server_pubkey_bytes)):
+        try:
+            return OnionReqParser(
+                crypto._server_pubkey_bytes[i],
+                crypto._server_privkey_bytes[i],
+                request.data)
+        except Exception as e:
+            pass
+
+    app.logger.warning(f"Failed to decrypt onion request (tried {len(crypto._server_pubkey_bytes)} pubkeys)")
     abort(http.BAD_REQUEST)
 
 

--- a/tests/test_onion_requests.py
+++ b/tests/test_onion_requests.py
@@ -22,14 +22,14 @@ assert A.encode().hex() == 'd79a50b82ba8ca665f854382b42ba159efd16eef87409e97a8d0
 # For xchacha20 we use the libsodium recommended shared key of H(aB || A || B), where H(.) is
 # 32-byte Blake2B
 shared_xchacha20_key = nacl.hashlib.blake2b(
-    crypto_scalarmult(a.encode(), crypto.privkey.public_key.encode())
+    crypto_scalarmult(a.encode(), crypto.privkeys[0].public_key.encode())
     + A.encode()
-    + crypto.privkey.public_key.encode(),
+    + crypto.privkeys[0].public_key.encode(),
     digest_size=32,
 ).digest()
 
 # AES-GCM onion requests were implemented using the somewhat weaker shared key of just aB:
-shared_aes_key = crypto_scalarmult(a.encode(), crypto.privkey.public_key.encode())
+shared_aes_key = crypto_scalarmult(a.encode(), crypto.privkeys[0].public_key.encode())
 
 
 def build_payload(inner_json, inner_body=None, *, v, enc_type, outer_json_extra={}):


### PR DESCRIPTION
Onion requests use X keys for shared secret generation, which causes problems with future functionality (lokinet, quic) that expects Ed25519 pubkeys.

This changes file server to use an Ed25519 keypair under the hood so that it can still do onion requests (using the Ed -> X converted keys), but that we can switch to using the master Ed25519 key everywhere and switch to X only when needed.

For compatibility, we now support *two* keys, if present on disk, one derived X from an Ed key, and one plain X key, and try both of them for onion decryption.  (This is a transition mechanism allowing us to convert to an Ed key for new clients without breaking old ones while the transition is underway).